### PR TITLE
feat(ComposedChart): add ComposedChart component with dual y-axes (bar + line)

### DIFF
--- a/src/ComposedChart/demos/axis.tsx
+++ b/src/ComposedChart/demos/axis.tsx
@@ -1,0 +1,24 @@
+import { ComposedChart, ComposedChartProps } from '@lobehub/charts';
+
+const data: ComposedChartProps['data'] = [
+  { month: 'Jan', revenue: 42_000, successRate: 94.2 },
+  { month: 'Feb', revenue: 51_000, successRate: 96.1 },
+  { month: 'Mar', revenue: 48_000, successRate: 95.5 },
+  { month: 'Apr', revenue: 63_000, successRate: 97.3 },
+  { month: 'May', revenue: 71_000, successRate: 98.0 },
+  { month: 'Jun', revenue: 68_000, successRate: 97.8 },
+];
+
+export default () => (
+  <ComposedChart
+    data={data}
+    index="month"
+    series={[
+      { axis: 'left', key: 'revenue', name: 'Revenue', type: 'bar' },
+      { axis: 'right', key: 'successRate', name: 'Success Rate (%)', type: 'line' },
+    ]}
+    xAxisLabel="Month"
+    yAxisLeft={{ label: 'Revenue (USD)', valueFormatter: (v) => `$${(v / 1000).toFixed(0)}k` }}
+    yAxisRight={{ label: 'Success Rate (%)', valueFormatter: (v) => `${v}%` }}
+  />
+);

--- a/src/ComposedChart/demos/example.tsx
+++ b/src/ComposedChart/demos/example.tsx
@@ -1,0 +1,29 @@
+import { ComposedChart, ComposedChartProps } from '@lobehub/charts';
+import { Flexbox } from '@lobehub/ui';
+
+const data: ComposedChartProps['data'] = [
+  { bucket: '0–1k', cost: 12.4, ops: 1200 },
+  { bucket: '1k–2k', cost: 28.7, ops: 2850 },
+  { bucket: '2k–5k', cost: 54.1, ops: 5400 },
+  { bucket: '5k–10k', cost: 87.3, ops: 8730 },
+  { bucket: '10k–20k', cost: 132.5, ops: 13_250 },
+  { bucket: '20k–50k', cost: 198.6, ops: 19_860 },
+  { bucket: '50k+', cost: 320.0, ops: 32_000 },
+];
+
+export default () => (
+  <Flexbox>
+    <h4>Token bucket distribution — requests vs cost</h4>
+    <ComposedChart
+      data={data}
+      height={320}
+      index="bucket"
+      series={[
+        { axis: 'left', key: 'ops', name: 'Requests', type: 'bar' },
+        { axis: 'right', key: 'cost', name: 'Cost (USD)', type: 'line' },
+      ]}
+      yAxisLeft={{ valueFormatter: (v) => v.toLocaleString() }}
+      yAxisRight={{ valueFormatter: (v) => `$${v.toFixed(2)}` }}
+    />
+  </Flexbox>
+);

--- a/src/ComposedChart/demos/index.tsx
+++ b/src/ComposedChart/demos/index.tsx
@@ -1,0 +1,24 @@
+import { ComposedChart, ComposedChartProps } from '@lobehub/charts';
+
+const data: ComposedChartProps['data'] = [
+  { bucket: '0–1k', cost: 12.4, ops: 1200 },
+  { bucket: '1k–2k', cost: 28.7, ops: 2850 },
+  { bucket: '2k–5k', cost: 54.1, ops: 5400 },
+  { bucket: '5k–10k', cost: 87.3, ops: 8730 },
+  { bucket: '10k–20k', cost: 132.5, ops: 13_250 },
+  { bucket: '20k–50k', cost: 198.6, ops: 19_860 },
+  { bucket: '50k+', cost: 320.0, ops: 32_000 },
+];
+
+export default () => (
+  <ComposedChart
+    data={data}
+    index="bucket"
+    series={[
+      { axis: 'left', key: 'ops', name: 'Requests', type: 'bar' },
+      { axis: 'right', key: 'cost', name: 'Cost (USD)', type: 'line' },
+    ]}
+    yAxisLeft={{ label: 'Requests', valueFormatter: (v) => v.toLocaleString() }}
+    yAxisRight={{ label: 'Cost (USD)', valueFormatter: (v) => `$${v.toFixed(2)}` }}
+  />
+);

--- a/src/ComposedChart/demos/loading.tsx
+++ b/src/ComposedChart/demos/loading.tsx
@@ -1,0 +1,13 @@
+import { ComposedChart } from '@lobehub/charts';
+
+export default () => (
+  <ComposedChart
+    data={[]}
+    index="bucket"
+    loading
+    series={[
+      { axis: 'left', key: 'ops', type: 'bar' },
+      { axis: 'right', key: 'cost', type: 'line' },
+    ]}
+  />
+);

--- a/src/ComposedChart/demos/noData.tsx
+++ b/src/ComposedChart/demos/noData.tsx
@@ -1,0 +1,12 @@
+import { ComposedChart } from '@lobehub/charts';
+
+export default () => (
+  <ComposedChart
+    data={[]}
+    index="bucket"
+    series={[
+      { axis: 'left', key: 'ops', type: 'bar' },
+      { axis: 'right', key: 'cost', type: 'line' },
+    ]}
+  />
+);

--- a/src/ComposedChart/index.md
+++ b/src/ComposedChart/index.md
@@ -1,0 +1,30 @@
+---
+nav: Components
+group: Charts
+description: ComposedChart renders bar and line series on the same chart with independent left and right y-axes, sharing a single x-axis and a unified tooltip.
+order: 2
+---
+
+<code src="./demos/index.tsx" nopadding></code>
+
+## Usage example
+
+A classic dual-axes chart: request count (bar, left axis) + average cost (line, right axis).
+
+<code src="./demos/example.tsx"></code>
+
+## Usage example with axis labels
+
+<code src="./demos/axis.tsx"></code>
+
+## No Data
+
+<code src="./demos/noData.tsx"></code>
+
+## Loading
+
+<code src="./demos/loading.tsx"></code>
+
+## API
+
+<API></API>

--- a/src/ComposedChart/index.tsx
+++ b/src/ComposedChart/index.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { Flexbox, Skeleton } from '@lobehub/ui';
+import { css, cssVar, cx } from 'antd-style';
+import { forwardRef, useMemo, useState } from 'react';
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart as ReChartsComposedChart,
+  Label,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import ChartLegend from '@/common/ChartLegend';
+import ChartTooltip from '@/common/ChartTooltip';
+import CustomYAxisTick from '@/common/CustomYAxisTick';
+import NoData from '@/common/NoData';
+import { useThemeColorRange } from '@/hooks/useThemeColorRange';
+import { defaultValueFormatter } from '@/utils';
+import { getMaxLabelLength } from '@/utils/getMaxLabelLength';
+
+import { styles } from './styles';
+import type { ComposedChartProps, SeriesItem } from './types';
+
+export type { ComposedChartProps, SeriesItem } from './types';
+
+const ComposedChart = forwardRef<HTMLDivElement, ComposedChartProps>((props, ref) => {
+  const themeColorRange = useThemeColorRange();
+  const {
+    data = [],
+    index,
+    series = [],
+    yAxisLeft,
+    yAxisRight,
+    colors = themeColorRange,
+    xAxisLabelFormatter = defaultValueFormatter,
+    startEndOnly = false,
+    animationDuration = 900,
+    showAnimation = false,
+    showXAxis = true,
+    showYAxis = true,
+    intervalType = 'equidistantPreserveStart',
+    showTooltip = true,
+    showLegend = true,
+    showGridLines = true,
+    allowDecimals = true,
+    noDataText,
+    enableLegendSlider = false,
+    rotateLabelX,
+    tickGap = 5,
+    loading,
+    xAxisLabel,
+    className,
+    width = '100%',
+    height = 280,
+    style,
+    ...rest
+  } = props;
+
+  const [activeLegend, setActiveLegend] = useState<string | undefined>();
+  const [legendHeight, setLegendHeight] = useState(60);
+
+  // Map series to colors
+  const seriesColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    series.forEach((s, i) => {
+      map.set(s.key, s.color ?? colors[i % colors.length]);
+    });
+    return map;
+  }, [series, colors]);
+
+  // Build legend payload format compatible with ChartLegend
+  const categoryColors = seriesColorMap;
+
+  const hasRightAxis = series.some((s) => s.axis === 'right');
+
+  const leftYAxisWidth = useMemo(() => {
+    if (yAxisLeft?.width) return yAxisLeft.width;
+    const leftFormatter = yAxisLeft?.valueFormatter ?? defaultValueFormatter;
+    return getMaxLabelLength({ data, index, layout: 'horizontal', valueFormatter: leftFormatter });
+  }, [yAxisLeft, data, index]);
+
+  const rightYAxisWidth = useMemo(() => {
+    if (yAxisRight?.width) return yAxisRight.width;
+    const rightFormatter = yAxisRight?.valueFormatter ?? defaultValueFormatter;
+    return getMaxLabelLength({ data, index, layout: 'horizontal', valueFormatter: rightFormatter });
+  }, [yAxisRight, data, index]);
+
+  if (loading || !data) return <Skeleton.Block active height={height} width={width} />;
+
+  const paddingValue = !showXAxis && !showYAxis ? 0 : 20;
+
+  return (
+    <Flexbox
+      className={className}
+      height={height}
+      ref={ref}
+      style={{ position: 'relative', ...style }}
+      width={width}
+      {...rest}
+    >
+      <ResponsiveContainer>
+        {data?.length ? (
+          <ReChartsComposedChart
+            data={data}
+            margin={{
+              bottom: xAxisLabel ? 30 : undefined,
+              left: yAxisLeft?.label ? 20 : undefined,
+              right: hasRightAxis ? (yAxisRight?.label ? 20 : 5) : undefined,
+              top: 5,
+            }}
+          >
+            {showGridLines && (
+              <CartesianGrid className={styles.gridLines} horizontal vertical={false} />
+            )}
+
+            <XAxis
+              angle={rotateLabelX?.angle}
+              axisLine={false}
+              className={styles.label}
+              dataKey={index}
+              dy={rotateLabelX?.verticalShift}
+              fill=""
+              hide={!showXAxis}
+              interval={startEndOnly ? 'preserveStartEnd' : intervalType}
+              minTickGap={tickGap}
+              padding={{ left: paddingValue, right: paddingValue }}
+              stroke=""
+              tick={{ transform: 'translate(0, 6)' }}
+              tickFormatter={xAxisLabelFormatter}
+              tickLine={false}
+              ticks={startEndOnly ? [data[0][index], data.at(-1)?.[index]] : undefined}
+            >
+              {xAxisLabel && (
+                <Label
+                  className={cx(styles.strongLabel, styles.emphasis)}
+                  offset={-20}
+                  position="insideBottom"
+                  style={{
+                    fill: cssVar.colorTextSecondary,
+                    fontWeight: 500,
+                    textAnchor: 'middle',
+                  }}
+                >
+                  {xAxisLabel}
+                </Label>
+              )}
+            </XAxis>
+
+            {/* Left Y Axis */}
+            <YAxis
+              allowDecimals={allowDecimals}
+              axisLine={false}
+              className={styles.label}
+              fill=""
+              hide={!showYAxis}
+              orientation="left"
+              stroke=""
+              tick={(tickProps) => (
+                <CustomYAxisTick
+                  {...tickProps}
+                  align="left"
+                  formatter={yAxisLeft?.valueFormatter ?? defaultValueFormatter}
+                  textAnchor="end"
+                  yAxisLabel={Boolean(yAxisLeft?.label)}
+                />
+              )}
+              tickFormatter={yAxisLeft?.valueFormatter ?? defaultValueFormatter}
+              tickLine={false}
+              type="number"
+              width={leftYAxisWidth}
+              yAxisId="left"
+            >
+              {yAxisLeft?.label && (
+                <Label
+                  angle={-90}
+                  className={styles.emphasis}
+                  offset={-15}
+                  position="insideLeft"
+                  style={{
+                    fill: cssVar.colorTextSecondary,
+                    fontWeight: 500,
+                    textAnchor: 'middle',
+                  }}
+                >
+                  {yAxisLeft.label}
+                </Label>
+              )}
+            </YAxis>
+
+            {/* Right Y Axis */}
+            {hasRightAxis && (
+              <YAxis
+                allowDecimals={allowDecimals}
+                axisLine={false}
+                className={styles.label}
+                fill=""
+                hide={!showYAxis}
+                orientation="right"
+                stroke=""
+                tick={(tickProps) => (
+                  <CustomYAxisTick
+                    {...tickProps}
+                    align="right"
+                    formatter={yAxisRight?.valueFormatter ?? defaultValueFormatter}
+                    textAnchor="start"
+                    yAxisLabel={Boolean(yAxisRight?.label)}
+                  />
+                )}
+                tickFormatter={yAxisRight?.valueFormatter ?? defaultValueFormatter}
+                tickLine={false}
+                type="number"
+                width={rightYAxisWidth}
+                yAxisId="right"
+              >
+                {yAxisRight?.label && (
+                  <Label
+                    angle={90}
+                    className={styles.emphasis}
+                    offset={-15}
+                    position="insideRight"
+                    style={{
+                      fill: cssVar.colorTextSecondary,
+                      fontWeight: 500,
+                      textAnchor: 'middle',
+                    }}
+                  >
+                    {yAxisRight.label}
+                  </Label>
+                )}
+              </YAxis>
+            )}
+
+            <Tooltip
+              content={
+                showTooltip
+                  ? ({ active, payload, label }) => (
+                      <ChartTooltip
+                        active={active}
+                        categoryColors={categoryColors}
+                        label={label}
+                        payload={payload?.map((item: any) => ({
+                          ...item,
+                          color: seriesColorMap.get(item.dataKey) ?? cssVar.colorPrimary,
+                        }))}
+                        valueFormatter={(value) => {
+                          // Try to find per-series formatter
+                          const s = series.find((s) => s.key === payload?.[0]?.dataKey);
+                          return s?.valueFormatter ? s.valueFormatter(value) : defaultValueFormatter(value);
+                        }}
+                      />
+                    )
+                  : undefined
+              }
+              cursor={{ fill: cssVar.colorFillTertiary }}
+              isAnimationActive={false}
+              position={{ y: 0 }}
+              wrapperStyle={{ outline: 'none' }}
+            />
+
+            {showLegend && (
+              <Legend
+                content={({ payload }) =>
+                  ChartLegend(
+                    { payload },
+                    categoryColors,
+                    setLegendHeight,
+                    activeLegend,
+                    undefined,
+                    enableLegendSlider,
+                  )
+                }
+                height={legendHeight}
+                verticalAlign="top"
+              />
+            )}
+
+            {series.map((s) => {
+              const color = seriesColorMap.get(s.key) ?? cssVar.colorPrimary;
+              const axisId = s.axis ?? 'left';
+
+              if (s.type === 'bar') {
+                return (
+                  <Bar
+                    animationDuration={animationDuration}
+                    className={cx(
+                      css`
+                        fill: ${color};
+                      `,
+                    )}
+                    dataKey={s.key}
+                    fill=""
+                    isAnimationActive={showAnimation}
+                    key={s.key}
+                    name={s.name ?? s.key}
+                    yAxisId={axisId}
+                  />
+                );
+              }
+
+              if (s.type === 'line') {
+                return (
+                  <Line
+                    animationDuration={animationDuration}
+                    className={cx(
+                      css`
+                        stroke: ${color};
+                      `,
+                    )}
+                    dataKey={s.key}
+                    dot={false}
+                    isAnimationActive={showAnimation}
+                    key={s.key}
+                    name={s.name ?? s.key}
+                    stroke=""
+                    strokeWidth={2}
+                    type="monotone"
+                    yAxisId={axisId}
+                  />
+                );
+              }
+
+              return null;
+            })}
+          </ReChartsComposedChart>
+        ) : (
+          <NoData noDataText={noDataText} />
+        )}
+      </ResponsiveContainer>
+    </Flexbox>
+  );
+});
+
+ComposedChart.displayName = 'ComposedChart';
+
+export default ComposedChart;

--- a/src/ComposedChart/styles.ts
+++ b/src/ComposedChart/styles.ts
@@ -1,0 +1,24 @@
+import { createStaticStyles } from 'antd-style';
+
+export const styles = createStaticStyles(({ css, cssVar }) => ({
+  emphasis: css`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  gridLines: css`
+    stroke: ${cssVar.colorBorderSecondary};
+    stroke-width: 1;
+  `,
+  label: css`
+    font-size: 12px;
+    line-height: 16px;
+    fill: ${cssVar.colorTextDescription};
+  `,
+  strongLabel: css`
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 16px;
+    fill: ${cssVar.colorTextSecondary};
+  `,
+}));

--- a/src/ComposedChart/types.ts
+++ b/src/ComposedChart/types.ts
@@ -1,0 +1,67 @@
+import type { ComponentType, HTMLAttributes } from 'react';
+
+import type { NoDataProps } from '@/common/NoData';
+import type { IntervalType, LabelFormatter, ValueFormatter } from '@/types/charts';
+
+import type BaseAnimationTimingProps from '../common/BaseAnimationTimingProps';
+
+export interface SeriesItem {
+  /**
+   * Which y-axis this series is bound to.
+   * @default 'left'
+   */
+  axis?: 'left' | 'right';
+  /** Override color for this series. Falls back to the chart-level `colors` array. */
+  color?: string;
+  /** Data key in the `data` array */
+  key: string;
+  /** Display name shown in legend / tooltip. Defaults to `key`. */
+  name?: string;
+  /** Chart type for this series */
+  type: 'bar' | 'line';
+  /** Per-series value formatter used in tooltip */
+  valueFormatter?: ValueFormatter;
+}
+
+export interface YAxisConfig {
+  /** Label string rendered alongside the axis */
+  label?: string;
+  /** Custom tick formatter */
+  valueFormatter?: ValueFormatter;
+  /** Fixed axis width in pixels */
+  width?: number;
+}
+
+export interface ComposedChartProps extends BaseAnimationTimingProps, HTMLAttributes<HTMLDivElement> {
+  allowDecimals?: boolean;
+  colors?: string[];
+  data: any[];
+  enableLegendSlider?: boolean;
+  height?: string | number;
+  /** The key in `data` used as the shared x-axis category */
+  index: string;
+  intervalType?: IntervalType;
+  loading?: boolean;
+  noDataText?: NoDataProps['noDataText'];
+  rotateLabelX?: {
+    angle: number;
+    verticalShift?: number;
+    xAxisHeight?: number;
+  };
+  /** Series definitions — each item maps to a Bar or Line renderer */
+  series: SeriesItem[];
+  showGridLines?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  startEndOnly?: boolean;
+  tickGap?: number;
+  width?: string | number;
+  xAxisLabel?: string;
+  xAxisLabelFormatter?: LabelFormatter;
+  /** Left y-axis configuration */
+  yAxisLeft?: YAxisConfig;
+  /** Right y-axis configuration */
+  yAxisRight?: YAxisConfig;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { type Bar, default as BarList, type BarListProps } from './BarList';
 export { default as ChartTooltip, type ChartTooltipProps } from './common/ChartTooltip';
 export { default as ChartTooltipFrame } from './common/ChartTooltip/ChartTooltipFrame';
 export { default as ChartTooltipRow } from './common/ChartTooltip/ChartTooltipRow';
+export { default as ComposedChart, type ComposedChartProps, type SeriesItem } from './ComposedChart';
 export * from './DataBars';
 export { default as DonutChart, type DonutChartProps } from './DonutChart';
 export { default as FunnelChart, type FunnelChartProps } from './FunnelChart';


### PR DESCRIPTION
## Summary

Closes https://linear.app/lobehub/issue/LOBE-9556

Adds a `ComposedChart` component that renders bar and line series on the same chart with independent left and right y-axes — the `DualAxes` equivalent that was missing from `@lobehub/charts`.

## What's new

### `ComposedChart`

```tsx
<ComposedChart
  data={data}
  index="time"
  series={[
    { type: 'bar',  key: 'ops',  axis: 'left',  name: 'Requests' },
    { type: 'line', key: 'cost', axis: 'right', name: 'Cost (USD)' },
  ]}
  yAxisLeft={{ label: '请求数', valueFormatter: (v) => v.toLocaleString() }}
  yAxisRight={{ label: '花费 USD', valueFormatter: (v) => `$${v.toFixed(2)}` }}
  height={320}
/>
```

**Key features:**
- Bar + Line (or any combination) rendered inside a single `recharts` `ComposedChart`
- Independent left / right `YAxis` via `yAxisId`, each with its own `valueFormatter` and optional `label`
- Per-series `color` override; falls back to chart-level `colors` array (theme color range)
- Shared x-axis + unified tooltip (hover a bar highlights the corresponding line point)
- `loading` / `noData` states consistent with existing components
- Fully typed via `SeriesItem` + `YAxisConfig` + `ComposedChartProps`

## Files

| File | Description |
|------|-------------|
| `src/ComposedChart/index.tsx` | Component implementation |
| `src/ComposedChart/types.ts` | `SeriesItem`, `YAxisConfig`, `ComposedChartProps` |
| `src/ComposedChart/styles.ts` | Shared static styles (same as BarChart) |
| `src/ComposedChart/index.md` | Doc page |
| `src/ComposedChart/demos/` | 5 demos (index, example, axis, noData, loading) |
| `src/index.ts` | Export `ComposedChart`, `ComposedChartProps`, `SeriesItem` |

## Related

Once merged, the token-report stacked workaround in DC can be replaced with a single `<ComposedChart>` and the `chart-color-convention` skill note about DualAxes workaround can be removed.
